### PR TITLE
Use App trait for the main program

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
-organization := "com.starcolon.flights"
+name         := "flights"
+organization := "com.starcolon"
+description  := "Travelling made easy with flights analysis"
+homepage     := Some(url("https://github.com/starcolon/flights"))
 
-version := "0.0.0"
+version := "0.0.1-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion   := "2.11.7"
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
 

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -3,36 +3,30 @@ package starcolon.flights.core
 /**
  * Core module of Flights
  */
-object Core {
-	import starcolon.flights.openflights._
-	import starcolon.flights.routemap._
-	import starcolon.flights.geo._
-	import scala.io.StdIn.{readLine,readInt}
+object Core extends App {
+  import starcolon.flights.openflights._
+  import starcolon.flights.routemap._
+  import starcolon.flights.geo._
+  import scala.io.StdIn.{readLine, readInt}
 
-  def main(args: Array[String]) {
-  	repl()
-  }
+  // Prompt the user for inputs
+  println("Let's find best routes!")
+  val citySource = readLine(Console.CYAN + "Source city: " + Console.RESET)
+  val cityDest   = readLine(Console.CYAN + "Destination city: " + Console.RESET)
+  print(Console.CYAN + "Max connections: " + Console.RESET)
+  var maxDegree  = readInt()
 
-  def repl(){
-  	// Prompt the user for inputs
-  	println("Let's find best routes!")
-		val citySource = readLine(Console.CYAN + "Source city: " + Console.RESET)
-		val cityDest   = readLine(Console.CYAN + "Destination city: " + Console.RESET)
-		print(Console.CYAN + "Max connections: " + Console.RESET)
-		var maxDegree  = readInt()
+  println(citySource + " ✈ ️ " + cityDest)
 
-		println(citySource + " ✈ ️ " + cityDest)
+  // Find direct flights between two cities
+  val routesDirect = RouteMap.findCityRoutes(citySource, cityDest)
+  println(Console.MAGENTA + "[Direct flights]" + Console.RESET)
+  routesDirect foreach {r => r.prettyPrint}
 
-		// Find direct flights between two cities
-		val routesDirect = RouteMap.findCityRoutes(citySource,cityDest)
-		println(Console.MAGENTA + "[Direct flights]" + Console.RESET)
-		routesDirect foreach {r => r.prettyPrint}
+  // Find indirect flights between two cities
+  val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
+  println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
 
-		// Find indirect flights between two cities
-		val routesIndirect = RouteMap.findCityIndirectRoutes(citySource,cityDest,maxDegree)
-		println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
-
-		// TAOTODO:
-		routesIndirect foreach {r => r.prettyPrint}
-  }	
+  // TAOTODO:
+  routesIndirect foreach {r => r.prettyPrint}
 }


### PR DESCRIPTION
The `App` trait is a little magic that runs its body as `main`, reducing boilerplate a little bit.

Reformatted the file with common Scala convention of indenting with two spaces. Tack `?w=0` onto GitHub URLs to see a cleaner diff view.
