### PR TITLE
Eliminate deprecation warnings, simplify Map defaults

### DIFF
--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -21,12 +21,12 @@ object Core extends App {
   // Find direct flights between two cities
   val routesDirect = RouteMap.findCityRoutes(citySource, cityDest)
   println(Console.MAGENTA + "[Direct flights]" + Console.RESET)
-  routesDirect foreach {r => r.prettyPrint}
+  routesDirect foreach { _.prettyPrint() }
 
   // Find indirect flights between two cities
   val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
   println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
 
   // TAOTODO:
-  routesIndirect foreach {r => r.prettyPrint}
+  routesIndirect foreach { _.prettyPrint() }
 }

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -60,14 +60,14 @@ object OpenFlights {
    */
   val routes: Map[RouteKey, List[Route]] = loadRoutesAsMap("/data/openflights/routes.dat")
 
-  def loadCSVDataFile(path: String): List[Array[String]] = {
+  private def loadCSVDataFile(path: String): List[Array[String]] = {
     val stream: InputStream = getClass.getResourceAsStream(path)
     val lines = io.Source.fromInputStream(stream).getLines
     val records = lines.map { line => line.split(",").map(_.trim) }
     records.toList
   }
 
-  def loadAirlinesAsMap(path: String): Map[String, List[Airline]] = {
+  private def loadAirlinesAsMap(path: String): Map[String, List[Airline]] = {
     val records = loadCSVDataFile(path)
     val index = Map.empty[String, List[Airline]].withDefaultValue(List())
 
@@ -86,7 +86,7 @@ object OpenFlights {
     }
   }
 
-  def loadAirlines(path: String): List[Airline] = {
+  private def loadAirlines(path: String): List[Airline] = {
     val records = loadCSVDataFile(path)
     records.foldLeft(List[Airline]()) { (list, n) =>
       list ++ List(Airline(
@@ -98,7 +98,7 @@ object OpenFlights {
     }
   }
 
-  def loadAirportsAsMap(path: String): Map[String, List[Airport]] = {
+  private def loadAirportsAsMap(path: String): Map[String, List[Airport]] = {
     val records = loadCSVDataFile(path)
     val index = Map.empty[String, List[Airport]].withDefaultValue(List())
 
@@ -131,7 +131,7 @@ object OpenFlights {
     }
   }
 
-  def loadAirports(path: String): List[Airport] = {
+  private def loadAirports(path: String): List[Airport] = {
     val records = loadCSVDataFile(path)
     records.foldLeft(List[Airport]()) { (list, n) =>
       if (n.length>12)
@@ -158,7 +158,7 @@ object OpenFlights {
     }
   }
 
-  def loadRoutesAsMap(path: String): Map[RouteKey, List[Route]] = {
+  private def loadRoutesAsMap(path: String): Map[RouteKey, List[Route]] = {
     val records = loadCSVDataFile(path)
     val index = Map.empty[RouteKey, List[Route]].withDefaultValue(List())
 
@@ -180,7 +180,7 @@ object OpenFlights {
     }
   }
 
-  def loadRoutes(path: String): List[Route] = {
+  private def loadRoutes(path: String): List[Route] = {
     val records = loadCSVDataFile(path)
     records.foldLeft(List[Route]()) { (list, n) => 
       list ++ List(Route(

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -6,15 +6,15 @@ import starcolon.flights.geo.Geo
 import scala.collection.mutable.Map
 
 case class Airline (id: Long, code: String, name: String, country: String){
-  def prettyPrint(){
+  def prettyPrint(): Unit = {
     println("✈️ " + Console.CYAN + name + " (" + code + ") " + Console.WHITE + country + Console.RESET)
   }
 }
 
 case class Airport (code: String, name: String, city: String, country: String, lat: Float, lng: Float){
-  def prettyPrint(){
     println("🏠 " + Console.CYAN + name + " (" + code + ") " + 
       Console.WHITE + city + "/" + country + Console.RESET)
+  def prettyPrint(): Unit = {
   }
 
   def isValidAirport() = code.length>0

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -43,7 +43,23 @@ case class RouteKey(airportSourceCode: String, airportDestCode: String)
 /**
  * OpenFlights data source handler
  */
-object OpenFlights{
+object OpenFlights {
+  /**
+   * A mapping of two-letter airline codes to the airlines that have used that
+   * code. It is possible for the codes of defunct airlines to be reassigned.
+   */
+  val airlines: Map[String, List[Airline]] = loadAirlinesAsMap("/data/openflights/airlines.dat")
+
+  /**
+   * A mapping of city names to the [[Airport]]s located in that city.
+   */
+  val airports: Map[String, List[Airport]] = loadAirportsAsMap("/data/openflights/airports.dat")
+
+  /**
+   * A mapping of [[Route]]s keyed by their (source, destination) pairs.
+   */
+  val routes: Map[RouteKey, List[Route]] = loadRoutesAsMap("/data/openflights/routes.dat")
+
   def loadCSVDataFile(path: String): List[Array[String]] = {
     val stream: InputStream = getClass.getResourceAsStream(path)
     val lines = io.Source.fromInputStream(stream).getLines
@@ -51,9 +67,11 @@ object OpenFlights{
     records.toList
   }
 
-  def loadAirlinesAsMap(path: String): Map[String,List[Airline]] = {
+  def loadAirlinesAsMap(path: String): Map[String, List[Airline]] = {
     val records = loadCSVDataFile(path)
-    records.foldLeft(Map[String,List[Airline]]()){ (map, n) => 
+    val index = Map.empty[String, List[Airline]].withDefaultValue(List())
+
+    records.foldLeft(index) { (index, n) =>
       // Airline code as a key
       val code    = n(4).replace("\"","")
       var airline = Airline(
@@ -63,12 +81,8 @@ object OpenFlights{
         n(6).replace("\"","")
       )
 
-      if (map.contains(code))
-        map(code) = map(code).+:(airline)
-      else
-        map(code) = List(airline)
-
-      map
+      index(code) = airline +: index(code)
+      index
     }
   }
 
@@ -84,39 +98,36 @@ object OpenFlights{
     }
   }
 
-  def loadAirportsAsMap(path: String): Map[String,List[Airport]] = {
+  def loadAirportsAsMap(path: String): Map[String, List[Airport]] = {
     val records = loadCSVDataFile(path)
-    records.foldLeft(Map[String,List[Airport]]()){ (map,n) =>
-      
-      // City as a key
-      val code    = if (n.length > 12)
-        (n(2)+", "+n(3)).replace("\"","")
-        else n(2).replace("\"","")
-    
-      val airport = if (n.length > 12) 
-        Airport(
-          n(4).replace("\"",""),
-          n(1).replace("\"",""),
-          (n(2)+", "+n(3)).replace("\"",""),
-          n(4).replace("\"",""),
-          n(7).toFloat,
-          n(8).toFloat
-        ) 
-        else Airport(
-          n(4).replace("\"",""),
-          n(1).replace("\"",""),
-          n(2).replace("\"",""),
-          n(3).replace("\"",""),
-          n(6).toFloat,
-          n(7).toFloat
-        )
+    val index = Map.empty[String, List[Airport]].withDefaultValue(List())
 
-      if (map.contains(code))
-        map(code) = map(code).+:(airport)
-      else 
-        map(code) = List(airport)
+    records.foldLeft(index) { (index, n) =>
+      val name = n(1).replace("\"", "")
 
-      map
+      // In case the city has a comma, it will be unintentionally split so we
+      // have one extra element in the split array.
+      val airport = if (n.length > 12) {
+        val city    = s"${n(2)}, ${n(3)}".replace("\"", "")
+        val country = n(4).replace("\"", "")
+        val code    = n(5).replace("\"", "")
+        val lat     = n(7).toFloat
+        val lng     = n(8).toFloat
+
+        Airport(code, name, city, country, lat, lng)
+      } else {
+        val city    = n(2).replace("\"", "")
+        val country = n(3).replace("\"", "")
+        val code    = n(4).replace("\"", "")
+        val lat     = n(6).toFloat
+        val lng     = n(7).toFloat
+
+        Airport(code, name, city, country, lat, lng)
+      }
+
+      val city = airport.city
+      index(city) = airport +: index(city)
+      index
     }
   }
 
@@ -147,26 +158,25 @@ object OpenFlights{
     }
   }
 
-  def loadRoutesAsMap(path: String): Map[RouteKey,List[Route]] = {
+  def loadRoutesAsMap(path: String): Map[RouteKey, List[Route]] = {
     val records = loadCSVDataFile(path)
-    records.foldLeft(Map[RouteKey,List[Route]]()) { (map, n) => 
-      var src      = n(2).replace("\"","")
-      var dst      = n(4).replace("\"","")
-      
+    val index = Map.empty[RouteKey, List[Route]].withDefaultValue(List())
+
+    records.foldLeft(index) { (index, n) =>
+      var src      = n(2).replace("\"", "")
+      var dst      = n(4).replace("\"", "")
+
       // Both src and dst airport codes as a key
-      var routeKey = RouteKey(src,dst)
+      var routeKey = RouteKey(src, dst)
       var route    = Route(
-        n(0).replace("\"",""),
-        n(2).replace("\"",""),
-        n(4).replace("\"",""),
+        n(0).replace("\"", ""),
+        src,
+        dst,
         n(7).toInt
       )
 
-      if (map.contains(routeKey))
-        map(routeKey) = map(routeKey).+:(route)
-      else
-        map(routeKey) = List(route)
-      map
+      index(routeKey) = route +: index(routeKey)
+      index
     }
   }
 
@@ -181,8 +191,4 @@ object OpenFlights{
       ))
     }
   }
-
-  val airlines = loadAirlinesAsMap("/data/openflights/airlines.dat")
-  val airports = loadAirportsAsMap("/data/openflights/airports.dat")
-  val routes   = loadRoutesAsMap("/data/openflights/routes.dat")
 }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -31,7 +31,7 @@ object RouteMap{
         
         println(Console.YELLOW + src.code + Console.WHITE + " to " + Console.YELLOW + dst.code + Console.RESET)
         println(r.length + " routes")
-        r foreach {n => n.prettyPrint}
+        r foreach { _.prettyPrint() }
 
         _route ++ r
       }


### PR DESCRIPTION
The deprecation warning change is explained in detail in its commit message.

The second change uses the ability to initialize a `Map` that will have a default value for unknown keys. This is easiest to see in the diff for `loadAirlinesAsMap` since the others have a bit of other refactoring.

I moved the important `val` fields on the `OpenFlights` object to the top so they are more prominent when reading, and gave them documentation and type annotations, since that is customary practice for public members. This is early informal, non-library code where visibility isn't hugely critical, but went ahead and made things private that are unlikely to be called beyond the initialization of the public fields.
