### PR TITLE
Automated source formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,3 +8,15 @@ version := "0.0.1-SNAPSHOT"
 scalaVersion   := "2.11.7"
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
 
+/**
+ * Automated source formatting upon compile, for consistency and focused code
+ * reviews.
+ */
+import com.typesafe.sbt.SbtScalariform
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+import scalariform.formatter.preferences._
+
+ScalariformKeys.preferences := ScalariformKeys.preferences.value
+  .setPreference(AlignSingleLineCaseStatements, true)
+  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(PreserveDanglingCloseParenthesis, true)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -7,14 +7,14 @@ object Core extends App {
   import starcolon.flights.openflights._
   import starcolon.flights.routemap._
   import starcolon.flights.geo._
-  import scala.io.StdIn.{readLine, readInt}
+  import scala.io.StdIn.{ readLine, readInt }
 
   // Prompt the user for inputs
   println("Let's find best routes!")
   val citySource = readLine(Console.CYAN + "Source city: " + Console.RESET)
-  val cityDest   = readLine(Console.CYAN + "Destination city: " + Console.RESET)
+  val cityDest = readLine(Console.CYAN + "Destination city: " + Console.RESET)
   print(Console.CYAN + "Max connections: " + Console.RESET)
-  var maxDegree  = readInt()
+  var maxDegree = readInt()
 
   println(citySource + " ✈ ️ " + cityDest)
 

--- a/src/main/scala/geo.scala
+++ b/src/main/scala/geo.scala
@@ -1,6 +1,6 @@
 package starcolon.flights.geo
 
-object Geo{
+object Geo {
   /**
    * Calculates a distance between two locations
    * returns distance in metres
@@ -12,7 +12,7 @@ object Geo{
     val flat = dlat.toFloat
     val flng = dlng.toFloat
 
-    Math.sqrt( flat*flat + flng*flng).toFloat
+    Math.sqrt(flat * flat + flng * flng).toFloat
   }
 
   /**

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -3,37 +3,37 @@ package starcolon.flights.openflights
 import starcolon.flights.geo.Geo
 import scala.collection.mutable.Map
 
-case class Airline (id: Long, code: String, name: String, country: String){
+case class Airline(id: Long, code: String, name: String, country: String) {
   def prettyPrint(): Unit = {
     println("✈️ " + Console.CYAN + name + " (" + code + ") " + Console.WHITE + country + Console.RESET)
   }
 }
 
-case class Airport (code: String, name: String, city: String, country: String, lat: Float, lng: Float){
+case class Airport(code: String, name: String, city: String, country: String, lat: Float, lng: Float) {
   def prettyPrint(): Unit = {
-    println("🏠 " + Console.CYAN + name + " (" + code + ") " + 
+    println("🏠 " + Console.CYAN + name + " (" + code + ") " +
       Console.WHITE + city + "/" + country + Console.RESET)
   }
 
-  def isValidAirport() = code.length>0
-  def isIn(_city: String) = city==_city
-  def isInCountry(_cn: String) = country==_cn
+  def isValidAirport() = code.length > 0
+  def isIn(_city: String) = city == _city
+  def isInCountry(_cn: String) = country == _cn
 }
 
-case class Route (airlineCode: String, airportSourceCode: String, airportDestCode: String, numStops: Int){
+case class Route(airlineCode: String, airportSourceCode: String, airportDestCode: String, numStops: Int) {
   def prettyPrint(): Unit = {
-    println(Console.CYAN + airlineCode + " ✈️ " + 
-      Console.GREEN + airportSourceCode + " ➡️ " + airportDestCode + " " + 
+    println(Console.CYAN + airlineCode + " ✈️ " +
+      Console.GREEN + airportSourceCode + " ➡️ " + airportDestCode + " " +
       Console.WHITE + numStops.toString + " stops" + Console.RESET)
   }
 
   def startsAt(_airportCode: String) = airportSourceCode == _airportCode
   def endsAt(_airportCode: String) = airportDestCode == _airportCode
-  def isBetween(_srcAirportCode: String, _dstAirportCode: String):Boolean = {
-    airportSourceCode == _srcAirportCode && 
-    airportDestCode == _dstAirportCode
+  def isBetween(_srcAirportCode: String, _dstAirportCode: String): Boolean = {
+    airportSourceCode == _srcAirportCode &&
+      airportDestCode == _dstAirportCode
   }
-  def isOperatedBy(_airline: String) = airlineCode==_airline
+  def isOperatedBy(_airline: String) = airlineCode == _airline
 }
 
 case class RouteKey(airportSourceCode: String, airportDestCode: String)
@@ -41,7 +41,7 @@ case class RouteKey(airportSourceCode: String, airportDestCode: String)
 /**
  * Another version of Route class with geolocations
  */
-case class GeoRoute(route: Route, srcLat: Float, srcLng: Float, dstLat: Float, dstLng: Float){
+case class GeoRoute(route: Route, srcLat: Float, srcLng: Float, dstLat: Float, dstLng: Float) {
   // Distance in metres between the source airport
   // and the destination airport
   def distance() = Geo.distance(srcLat, srcLng, dstLat, dstLng)
@@ -80,12 +80,12 @@ object OpenFlights {
 
     records.foldLeft(index) { (index, n) =>
       // Airline code as a key
-      val code    = n(4).replace("\"","")
+      val code = n(4).replace("\"", "")
       var airline = Airline(
         n(0).toLong,
-        n(4).replace("\"",""),
-        n(1).replace("\"",""),
-        n(6).replace("\"","")
+        n(4).replace("\"", ""),
+        n(1).replace("\"", ""),
+        n(6).replace("\"", "")
       )
 
       index(code) = airline +: index(code)
@@ -98,9 +98,9 @@ object OpenFlights {
     records.foldLeft(List[Airline]()) { (list, n) =>
       list ++ List(Airline(
         n(0).toLong,
-        n(4).replace("\"",""),
-        n(1).replace("\"",""),
-        n(6).replace("\"","")
+        n(4).replace("\"", ""),
+        n(1).replace("\"", ""),
+        n(6).replace("\"", "")
       ))
     }
   }
@@ -115,19 +115,19 @@ object OpenFlights {
       // In case the city has a comma, it will be unintentionally split so we
       // have one extra element in the split array.
       val airport = if (n.length > 12) {
-        val city    = s"${n(2)}, ${n(3)}".replace("\"", "")
+        val city = s"${n(2)}, ${n(3)}".replace("\"", "")
         val country = n(4).replace("\"", "")
-        val code    = n(5).replace("\"", "")
-        val lat     = n(7).toFloat
-        val lng     = n(8).toFloat
+        val code = n(5).replace("\"", "")
+        val lat = n(7).toFloat
+        val lng = n(8).toFloat
 
         Airport(code, name, city, country, lat, lng)
       } else {
-        val city    = n(2).replace("\"", "")
+        val city = n(2).replace("\"", "")
         val country = n(3).replace("\"", "")
-        val code    = n(4).replace("\"", "")
-        val lat     = n(6).toFloat
-        val lng     = n(7).toFloat
+        val code = n(4).replace("\"", "")
+        val lat = n(6).toFloat
+        val lng = n(7).toFloat
 
         Airport(code, name, city, country, lat, lng)
       }
@@ -141,24 +141,24 @@ object OpenFlights {
   private def loadAirports(path: String): List[Airport] = {
     val records = loadCSVDataFile(path)
     records.foldLeft(List[Airport]()) { (list, n) =>
-      if (n.length>12)
+      if (n.length > 12)
         // In case the city has a comma,
         // it will be unintentionally splitted so we have
         // one extra element in the splitted array.
         list ++ List(Airport(
-          n(4).replace("\"",""),
-          n(1).replace("\"",""),
-          (n(2)+", "+n(3)).replace("\"",""),
-          n(4).replace("\"",""),
+          n(4).replace("\"", ""),
+          n(1).replace("\"", ""),
+          (n(2) + ", " + n(3)).replace("\"", ""),
+          n(4).replace("\"", ""),
           n(7).toFloat,
           n(8).toFloat
         ))
       else
         list ++ List(Airport(
-          n(4).replace("\"",""),
-          n(1).replace("\"",""),
-          n(2).replace("\"",""),
-          n(3).replace("\"",""),
+          n(4).replace("\"", ""),
+          n(1).replace("\"", ""),
+          n(2).replace("\"", ""),
+          n(3).replace("\"", ""),
           n(6).toFloat,
           n(7).toFloat
         ))
@@ -170,12 +170,12 @@ object OpenFlights {
     val index = Map.empty[RouteKey, List[Route]].withDefaultValue(List())
 
     records.foldLeft(index) { (index, n) =>
-      var src      = n(2).replace("\"", "")
-      var dst      = n(4).replace("\"", "")
+      var src = n(2).replace("\"", "")
+      var dst = n(4).replace("\"", "")
 
       // Both src and dst airport codes as a key
       var routeKey = RouteKey(src, dst)
-      var route    = Route(
+      var route = Route(
         n(0).replace("\"", ""),
         src,
         dst,
@@ -189,11 +189,11 @@ object OpenFlights {
 
   private def loadRoutes(path: String): List[Route] = {
     val records = loadCSVDataFile(path)
-    records.foldLeft(List[Route]()) { (list, n) => 
+    records.foldLeft(List[Route]()) { (list, n) =>
       list ++ List(Route(
-        n(0).replace("\"",""),
-        n(2).replace("\"",""),
-        n(4).replace("\"",""),
+        n(0).replace("\"", ""),
+        n(2).replace("\"", ""),
+        n(4).replace("\"", ""),
         n(7).toInt
       ))
     }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -6,7 +6,7 @@ import starcolon.flights.geo._
 /**
  * Route mapper/finder utility
  */
-object RouteMap{
+object RouteMap {
   /**
    * Find all airports located in a particular city
    */
@@ -19,10 +19,10 @@ object RouteMap{
     val srcAirports = findAirports(citySrc).filter(_.isValidAirport)
     val dstAirports = findAirports(cityDest).filter(_.isValidAirport)
 
-    srcAirports.foldLeft(List[Route]()) { (route,src) =>
-      route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) => 
+    srcAirports.foldLeft(List[Route]()) { (route, src) =>
+      route ++ dstAirports.foldLeft(List[Route]()) { (_route, dst) =>
         val r = findAirportRoutes(src.code, dst.code)
-        
+
         // println(Console.YELLOW + src.code + Console.WHITE + " to " + Console.YELLOW + dst.code + Console.RESET)
         // println(r.length + " routes")
         // r foreach {n => n.prettyPrint}
@@ -39,8 +39,8 @@ object RouteMap{
     val dstAirports = findAirports(cityDest).filter(_.isValidAirport)
 
     // Examine each pair of the src-dst airports
-    srcAirports.foldLeft(List[Route]()) { (route,src) =>
-      route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) =>
+    srcAirports.foldLeft(List[Route]()) { (route, src) =>
+      route ++ dstAirports.foldLeft(List[Route]()) { (_route, dst) =>
         val r = findIndirectAirportRoutes(src.code, dst.code, maxDegree)
 
         // println(Console.YELLOW + src.code + Console.WHITE + " to " + Console.YELLOW + dst.code + Console.RESET)
@@ -50,9 +50,9 @@ object RouteMap{
         _route ++ r
       }
     }
-  
+
     return List[Route]()
-  } 
+  }
 
   /**
    * Find all direct routes between two airports


### PR DESCRIPTION
This adds an sbt plugin for the [Scalariform](http://scala-ide.org/scalariform/) Scala formatter which automatically applies formatting conventions to the project every time `compile` is run. One thing I can appreciate about the Go world is `gofmt` keeping style consistent and removing that distraction from code reading and reviews.

This configures a few settings that I happen to like and that come close to [standards adopted for the standard library](http://scala-ide.org/scalariform/#id1). If you want to change some, I don't much care what the settings are, more important to me that they're automatic.

It's possible to disable formatting manually for blocks of code by surrounding with `// format: OFF` & `// format: ON` comments—I can agree that sometimes a block of aligned `=` assignments helps readability, for example.

An alternative is [Scalastyle](http://www.scalastyle.org/) which might support more rules and configuration flexibility, but it gives you a lot of choices to make with an XML config file, and critically (to me) it doesn't actually apply formatting automatically, it just tells you what you ought to fix (and optionally fails your sbt build if not compliant).
