### PR TITLE
Use a CSV parser lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,10 @@ homepage     := Some(url("https://github.com/starcolon/flights"))
 
 version := "0.0.1-SNAPSHOT"
 
-scalaVersion   := "2.11.7"
+scalaVersion   := "2.11.8"
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xlint")
+
+libraryDependencies += "com.nrinaudo" %% "kantan.csv" % "0.1.9"
 
 /**
  * Automated source formatting upon compile, for consistency and focused code

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -59,19 +59,19 @@ object OpenFlights {
    * code. It is possible for the codes of defunct airlines to be reassigned.
    */
   lazy val airlines: Map[String, List[Airline]] =
-    asMultiMap(loadAirlines("/data/openflights/airlines.dat"), airline => airline.code)
+    asMultiMap(loadCSV[Airline]("/data/openflights/airlines.dat"), airline => airline.code)
 
   /**
    * A mapping of city names to the [[Airport]]s located in that city.
    */
   lazy val airports: Map[String, List[Airport]] =
-    asMultiMap(loadAirports("/data/openflights/airports.dat"), airport => airport.city)
+    asMultiMap(loadCSV[Airport]("/data/openflights/airports.dat"), airport => airport.city)
 
   /**
    * A mapping of [[Route]]s keyed by their (source, destination) pairs.
    */
   lazy val routes: Map[RouteKey, List[Route]] = {
-    val records = loadRoutes("/data/openflights/routes.dat")
+    val records = loadCSV[Route]("/data/openflights/routes.dat")
     asMultiMap(records, route => RouteKey(route.airportSourceCode, route.airportDestCode))
   }
 
@@ -90,20 +90,11 @@ object OpenFlights {
    * @tparam T The class represented by records in the CSV. Requires a
    *   [[kantan.csv.RowDecoder]] instance for the type available in scope.
    */
-  private def loadCSVDataFile[T: RowDecoder](path: String): List[T] = {
+  private def loadCSV[T: RowDecoder](path: String): List[T] = {
     val url = getClass.getResource(path)
     // We have a static, well-formed data set -- unsafe causes no errors.
     url.unsafeReadCsv[List, T](',', false) // comma separator, no header
   }
-
-  /** Load a list of [[Airline]]s, given a path to a CSV file. */
-  private def loadAirlines(path: String): List[Airline] = loadCSVDataFile[Airline](path)
-
-  /** Load a list of [[Airport]]s, given a path to a CSV file. */
-  private def loadAirports(path: String): List[Airport] = loadCSVDataFile[Airport](path)
-
-  /** Load a list of [[Routes]]s, given a path to a CSV file. */
-  private def loadRoutes(path: String): List[Route] = loadCSVDataFile[Route](path)
 
   /**
    * Creates a multi-Map from a list, using the given keyfunc to derive a map


### PR DESCRIPTION
You may not want to accept this at this point in time just because understanding this library in depth requires familiarity with pretty advanced features of Scala—if you feel like you're not ready to tackle it, no worries, I just tried this as an experiment for myself and I thought I'd share the branch after getting it working.

It's helpful to look at the commits in this branch one-at-a-time.

You'd think parsing CSV is simple, but there is complexity when it comes to varying formats accepted by standards, quoting, etc. Our existing special-case handling of city names with commas inside quoted fields evinced one such example. So this change lets a library, [kantan.csv](https://github.com/nrinaudo/kantan.csv), handle the parsing. It's [reasonably fast](https://nrinaudo.github.io/kantan.csv/tut/benchmarks.html), too.

It's common for Scala serialization libraries (JSON, CSV, etc.) to use implementations based on typeclasses, so that by making your own OO classes instances of the appropriate typeclass provided by the library, they can be encoded and decoded. This is just like the concept of typeclasses in Haskell that you're probably familiar with, but in Scala typeclasses are not a built-in language feature, they're implemented using other features and this results in the syntax being a lot more verbose in Scala. Plus it involves implicits, one of the most complex features of Scala. It can all get pretty hairy. People start to turn to libraries from what I call "the Haskell side of the Scala ecosystem" to get better support and syntactic sugar for typeclasses, like [shapeless](https://github.com/milessabin/shapeless), [scalaz](https://github.com/scalaz/scalaz), and [cats](https://github.com/typelevel/cats). These are some of the most infamously mind-blowing libraries popular in Scala, getting into category theory territory and favoring a purely functional style using modules and typeclasses more than the object-oriented side.

Much of that mind-bending comes from _writing_ libraries in that style though, _using_ the libraries in many cases—like serialization—isn't as difficult to understand. These pages of the kantan.csv docs are pertinent:
- https://nrinaudo.github.io/kantan.csv/tut/rows_as_case_classes.html
- https://nrinaudo.github.io/kantan.csv/tut/data_as_collection.html

Here's a [pretty good introductory article for typeclasses in Scala](http://danielwestheide.com/blog/2013/02/06/the-neophytes-guide-to-scala-part-12-type-classes.html) if you want to start learning them.
