### PR TITLE
Finding indirect route (simple implementation)

### DIFF
--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -26,5 +26,5 @@ object Core extends App {
   // Find indirect flights between two cities
   val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
   println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
-  routesIndirect foreach { _.prettyPrint() }
+  // routesIndirect foreach { _.prettyPrint() }
 }

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -26,7 +26,5 @@ object Core extends App {
   // Find indirect flights between two cities
   val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
   println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
-
-  // TAOTODO:
   routesIndirect foreach { _.prettyPrint() }
 }

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -20,11 +20,21 @@ object Core extends App {
 
   // Find direct flights between two cities
   val routesDirect = RouteMap.findCityRoutes(citySource, cityDest)
+  var routesIndirect = List[List[GeoRoute]]()
+
+  if (maxDegree>1){
+    // Find indirect flights between two cities
+    routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
+  }
+
+  // Report time!
+  println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
+  routesIndirect foreach { routes => 
+    println(Console.CYAN + "[ROUTE]" + Console.RESET)
+    routes.foreach {_.prettyPrint("   ")}
+  }
+
   println(Console.MAGENTA + "[Direct flights]" + Console.RESET)
   routesDirect foreach { _.prettyPrint() }
 
-  // Find indirect flights between two cities
-  val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
-  println(Console.MAGENTA + "[Indirect flights]" + Console.RESET)
-  // routesIndirect foreach { _.prettyPrint() }
 }

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -48,8 +48,8 @@ case class GeoRoute(route: Route, srcLat: Float, srcLng: Float, dstLat: Float, d
   // and the destination airport
   def distance() = Geo.distance(srcLat, srcLng, dstLat, dstLng)
 
-  def prettyPrint(){
-    println(Console.CYAN + route.airlineCode + " ✈️ " + 
+  def prettyPrint(prefix: String=""){
+    println(prefix + Console.CYAN + route.airlineCode + " ✈️ " + 
       Console.GREEN + route.airportSourceCode + " ➡️ " + route.airportDestCode + " " + 
       Console.WHITE + route.numStops.toString + " stops " + 
       Console.YELLOW + distance()/1000 + " km" +

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -47,6 +47,14 @@ case class GeoRoute(route: Route, srcLat: Float, srcLng: Float, dstLat: Float, d
   // Distance in metres between the source airport
   // and the destination airport
   def distance() = Geo.distance(srcLat, srcLng, dstLat, dstLng)
+
+  def prettyPrint(){
+    println(Console.CYAN + route.airlineCode + " ✈️ " + 
+      Console.GREEN + route.airportSourceCode + " ➡️ " + route.airportDestCode + " " + 
+      Console.WHITE + route.numStops.toString + " stops " + 
+      Console.YELLOW + distance()/1000 + " km" +
+      Console.RESET)
+  }
 }
 
 /**

--- a/src/main/scala/openflights.scala
+++ b/src/main/scala/openflights.scala
@@ -182,10 +182,10 @@ object OpenFlights {
       .withDefaultValue(initialMap)
 
     records.foldLeft(index) { (index, n) =>
-      var src      = n(2).replace("\"", "")
-      var dst      = n(4).replace("\"", "")
+      var src   = n(2).replace("\"", "")
+      var dst   = n(4).replace("\"", "")
 
-      var route    = Route(
+      var route = Route(
         n(0).replace("\"", ""),
         src,
         dst,
@@ -193,7 +193,12 @@ object OpenFlights {
       )
 
       // Ensure mapping: source -> dest -> [Route]
-      index(src)(dst) = route +: index(src)(dst)
+      if (!index.contains(src))
+        index(src) = Map()
+      if (!index(src).contains(dst))
+        index(src)(dst) = List(route)
+      else
+        index(src)(dst) = route +: index(src)(dst)
       index
     }
   }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -20,12 +20,12 @@ object RouteMap{
   /**
    * Find all routes between two cities
    */
-  def findCityRoutes(citySrc: String, cityDest: String): List[Route] = {
+  def findCityRoutes(citySrc: String, cityDest: String): List[GeoRoute] = {
     val srcAirports = findAirports(citySrc).filter(_.isValidAirport)
     val dstAirports = findAirports(cityDest).filter(_.isValidAirport)
 
-    srcAirports.foldLeft(List[Route]()) { (route,src) =>
-      route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) => 
+    srcAirports.foldLeft(List[GeoRoute]()) { (route,src) =>
+      route ++ dstAirports.foldLeft(List[GeoRoute]()) { (_route,dst) => 
         val r = findAirportRoutes(src, dst)
         _route ++ r
       }
@@ -35,42 +35,47 @@ object RouteMap{
   /**
    * Find indirect routes which connect two cities
    */
-  def findCityIndirectRoutes(citySrc: String, cityDest: String, maxDegree: Int): List[Route] = {
+  def findCityIndirectRoutes(citySrc: String, cityDest: String, maxDegree: Int): List[GeoRoute] = {
     val srcAirports = findAirports(citySrc).filter(_.isValidAirport)
     val dstAirports = findAirports(cityDest).filter(_.isValidAirport)
 
     // Examine each pair of the src-dst airports
-    srcAirports.foldLeft(List[Route]()) { (route,src) =>
-      route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) =>
+    srcAirports.foldLeft(List[GeoRoute]()) { (route,src) =>
+      route ++ dstAirports.foldLeft(List[GeoRoute]()) { (_route,dst) =>
         val r = findIndirectAirportRoutes(src, dst, maxDegree)
         _route ++ r
       }
     }
   
-    return List[Route]()
+    return List[GeoRoute]()
   } 
 
   /**
    * Find all direct routes between two airports
    */
-  def findAirportRoutes(airportSrc: Airport, airportDest: Airport): List[Route] = {
+  def findAirportRoutes(airportSrc: Airport, airportDest: Airport): List[GeoRoute] = {
 
     if (OpenFlights.routes.contains(airportSrc.code) &&
         OpenFlights.routes(airportSrc.code).contains(airportDest.code))
           return OpenFlights.routes(airportSrc.code)(airportDest.code)
+            .map(r => GeoRoute(
+              r,
+              airportSrc.lat, airportSrc.lng,
+              airportDest.lat, airportDest.lng
+              ))
     else
-      return List[Route]()
+      return List[GeoRoute]()
   }
 
   /**
    * Find all indirect routes between two airports
    * There is at least one connecting airport between the two.
    */
-  def findIndirectAirportRoutes(airportSrc: Airport, airportDest: Airport, maxDegree: Int): List[Route] = {
+  def findIndirectAirportRoutes(airportSrc: Airport, airportDest: Airport, maxDegree: Int): List[GeoRoute] = {
 
     // Perform a depth-first-search
     // TAOTODO:
-    return List[Route]()
+    return List[GeoRoute]()
   }
 
 }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -27,10 +27,6 @@ object RouteMap{
     srcAirports.foldLeft(List[Route]()) { (route,src) =>
       route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) => 
         val r = findAirportRoutes(src.code, dst.code)
-        
-        // println(Console.YELLOW + src.code + Console.WHITE + " to " + Console.YELLOW + dst.code + Console.RESET)
-        // println(r.length + " routes")
-        // r foreach {n => n.prettyPrint}
         _route ++ r
       }
     }
@@ -47,11 +43,6 @@ object RouteMap{
     srcAirports.foldLeft(List[Route]()) { (route,src) =>
       route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) =>
         val r = findIndirectAirportRoutes(src.code, dst.code, maxDegree)
-
-        // println(Console.YELLOW + src.code + Console.WHITE + " to " + Console.YELLOW + dst.code + Console.RESET)
-        // println(r.length + " routes")
-        // r foreach {n => n.prettyPrint}
-
         _route ++ r
       }
     }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -96,6 +96,10 @@ object RouteMap{
     if (maxDegree<=0)
       return List()
 
+    // TAOTODO: Other stopping criteria:
+    // - Too large total distance
+    // - Too large one single distance of a flight
+
     println(Console.CYAN + "==================================" + Console.RESET)
     println(Console.CYAN + s"[Max ${maxDegree} degrees left]..." + Console.RESET)
     println(Console.GREEN + "Expanding route from: " + prevRoute.map(_.route.airportSourceCode).mkString(" ➡️ ") + 

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -26,7 +26,7 @@ object RouteMap{
 
     srcAirports.foldLeft(List[Route]()) { (route,src) =>
       route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) => 
-        val r = findAirportRoutes(src.code, dst.code)
+        val r = findAirportRoutes(src, dst)
         _route ++ r
       }
     }
@@ -42,7 +42,7 @@ object RouteMap{
     // Examine each pair of the src-dst airports
     srcAirports.foldLeft(List[Route]()) { (route,src) =>
       route ++ dstAirports.foldLeft(List[Route]()) { (_route,dst) =>
-        val r = findIndirectAirportRoutes(src.code, dst.code, maxDegree)
+        val r = findIndirectAirportRoutes(src, dst, maxDegree)
         _route ++ r
       }
     }
@@ -53,11 +53,11 @@ object RouteMap{
   /**
    * Find all direct routes between two airports
    */
-  def findAirportRoutes(airportSrc: String, airportDest: String): List[Route] = {
+  def findAirportRoutes(airportSrc: Airport, airportDest: Airport): List[Route] = {
 
-    if (OpenFlights.routes.contains(airportSrc) &&
-        OpenFlights.routes(airportSrc).contains(airportDest))
-          return OpenFlights.routes(airportSrc)(airportDest)
+    if (OpenFlights.routes.contains(airportSrc.code) &&
+        OpenFlights.routes(airportSrc.code).contains(airportDest.code))
+          return OpenFlights.routes(airportSrc.code)(airportDest.code)
     else
       return List[Route]()
   }
@@ -66,8 +66,9 @@ object RouteMap{
    * Find all indirect routes between two airports
    * There is at least one connecting airport between the two.
    */
-  def findIndirectAirportRoutes(airportSrc: String, airportDest: String, maxDegree: Int): List[Route] = {
+  def findIndirectAirportRoutes(airportSrc: Airport, airportDest: Airport, maxDegree: Int): List[Route] = {
 
+    // Perform a depth-first-search
     // TAOTODO:
     return List[Route]()
   }

--- a/src/main/scala/routemap.scala
+++ b/src/main/scala/routemap.scala
@@ -54,9 +54,10 @@ object RouteMap{
    * Find all direct routes between two airports
    */
   def findAirportRoutes(airportSrc: String, airportDest: String): List[Route] = {
-    val key = RouteKey(airportSrc,airportDest)
-    if (OpenFlights.routes.contains(key))
-      return OpenFlights.routes(key)
+
+    if (OpenFlights.routes.contains(airportSrc) &&
+        OpenFlights.routes(airportSrc).contains(airportDest))
+          return OpenFlights.routes(airportSrc)(airportDest)
     else
       return List[Route]()
   }


### PR DESCRIPTION
**Added feature:**

> Finding indirect routes which connect two given cities. The number of connections is constrained by the user input (max connections). The connected routes are not necessarily operated by the same airline.

Adding this small feature however requires some collection structural changes. The recent collection structure works well with direct route finding but not connecting flights. Notable changes are:
- [x] Airport data is now read and stored into two separate mappings: `airport code` -> `Airport` and `city` -> `[Airport]`. Therefore we can lookup airport object from its code and also lookup all airports in a given city like we previously could.
- [x] No longer store routes as a mapping which uses both `source airport code` and `destination airport code` as _single assembled key_. 
- [x] Instead, now use a mapping from `source airport code` to a mapping from `destination airport code` to a list of `Route`. With this, we can browse all routes which start from a certain airport - in favour of route traversal.
- [x] Make use of `GeoRoute` for storing a route with its terminal geolocations for distance calculation.
## 

**Short note of indirect route finding**
At this early stage, I use a simple depth-first-search to browse appropriate connecting routes until it reach the final destination airport. Some connecting routes may not make sense (e.g. From BKK -> Sydney may end up: BKK -> Mumbai -> Sydney which is too funny for someone to take). Enhancement will be soon to come!

Also, this change still use the old implementation of CSV reading mechanism. Merging with #4 will be next thing to do :hammer: 
