### PR TITLE
Nix blocking Awaits in RouteMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "com.nrinaudo" %% "kantan.csv" % "0.1.9",
   "com.typesafe" % "config" % "1.3.0",
   "org.slf4j" % "slf4j-nop" % "1.6.4",
-  "com.typesafe.slick" %% "slick" % "3.0.0",
+  "com.typesafe.slick" %% "slick" % "3.1.1",
   "com.h2database" % "h2" % "1.4.192"
 )
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,12 @@
 flightDB = {
   url = "jdbc:h2:mem:flights"
   driver = org.h2.Driver
-  connectionPool = disabled
   keepAliveConnection = true
+
+  # Strongly recommended to use the default of HikariCP for real production apps
+  connectionPool = disabled
+
+  # Inadvisable hack because we're doing graph operations that execute an
+  # unreasonable number of queries with no memoization...
+  queueSize = -1
 }

--- a/src/main/scala/core.scala
+++ b/src/main/scala/core.scala
@@ -53,8 +53,9 @@ object Core extends App {
     // Find indirect flights between two cities
     if (maxDegree > 0) {
       val routesIndirect = RouteMap.findCityIndirectRoutes(citySource, cityDest, maxDegree)
+      val results = Await.result(routesIndirect, 30.seconds)
 
-      routesIndirect foreach { _.prettyPrint() }
+      results foreach { _.prettyPrint() }
     }
 
     println(Console.GREEN + "Try again, or Ctrl + C to quit" + Console.RESET)


### PR DESCRIPTION
You mentioned not being sure yet about the idiomatic concurrency models, this changeset largely addresses that so maybe it's instructive. Since you have a Haskell background I think you can probably succinctly understand it from this summary:

_Scala's `Future` is a monad, and the context that it represents is asynchronous processing. Generally, you want to use the combinator methods on `Future` and its companion object (`map`, `flatMap`, `filter`, `sequence`, `reduce`, etc.) to keep operating "within the monad" until "the end of the world"—in our case the `Core` app when results finally get used, where we finally will use `Await.result`._

So, within the block of a `map` or `flatMap` you can act as if you already have the (successful) result of the future to work with, but the map will return a `Future` again, propagating the async context. The common pattern is that you'll have a library like Slick or an HTTP client returning `Future` results to you, and you map over them to act and return another transformed `Future`, just like you had already done in the functions in the `OpenFlightsDB` module. At the "end of the world" you'll unwrap them. Sometimes frameworks even do the unwrapping for you, like in the Play web framework you can usually return `Future`s from your controller functions and the framework will stream the results back to clients as HTTP responses whenever the `Future`s get completed.

This does take practice to get familiar with. It still takes me some time to switch into the monad mindset whenever working with the Scala futures APIs.

So in this branch what I've mainly done is refactor to use the `Future` combinators to eliminate all the internal `Await` usage, making all the functions in `RouteMap` that call Slick queries non-blocking.

There is one semantic change: you were returning a `Map` from `findIndirectRoutesFromAirport`, but you weren't really making use of the property of this being keyed by destination airport, it was just getting flattened into sequences of routes downstream anyway. So to make the types match up easily and to be more consistent with the rest of the API, I changed that (and its recursion helper function) to return a (`Future`) `Seq` also. It should be easy to add back a variation returning a `Map` if it's actually needed later.

I have no idea yet how the code organization may change if we also try out a graph DB for some of these operations, but I figured this could be useful until we get to that point.
